### PR TITLE
Checks for JSON in the options Array instead.

### DIFF
--- a/jquery-ajax-localstorage-cache.js
+++ b/jquery-ajax-localstorage-cache.js
@@ -1,4 +1,3 @@
-
 // github.com/paulirish/jquery-ajax-localstorage-cache
 // dependent on Modernizr's localStorage test
 
@@ -29,7 +28,7 @@ $.ajaxPrefilter( function( options, originalOptions, jqXHR ) {
   if( value ){
     //In the cache? So get it, apply success callback & abort the XHR request
     // parse back to JSON if we can.
-    if (value.indexOf('{') === 0) value = JSON.parse(value);
+    if (options.dataType.indexOf('json') === 0) value = JSON.parse(value);
     options.success( value );
     // Abort is broken on JQ 1.5 :(
     jqXHR.abort();


### PR DESCRIPTION
The current implementation breaks if the object is for example an array.
