### PR TITLE
Catch exceptions when saving to localStorage, which should catch over quota errors.

### DIFF
--- a/jquery-ajax-localstorage-cache.js
+++ b/jquery-ajax-localstorage-cache.js
@@ -40,7 +40,17 @@ $.ajaxPrefilter( function( options, originalOptions, jqXHR ) {
     options.success = function( data ) {
       var strdata = data;
       if ( this.dataType.indexOf( 'json' ) === 0 ) strdata = JSON.stringify( data );
-      localStorage.setItem( cacheKey, strdata );
+
+      // Save the data to localStorage catching exceptions (possibly QUOTA_EXCEEDED_ERR)
+      try {
+        localStorage.setItem( cacheKey, strdata );
+      } catch (e) {
+        // Remove any incomplete data that may have been saved before the exception was caught
+        localStorage.removeItem( cacheKey );
+        localStorage.removeItem( cacheKey + 'cachettl' );
+        if ( options.cacheError ) options.cacheError( e, cacheKey, strdata );
+      }
+
       if ( options.realsuccess ) options.realsuccess( data );
     };
 


### PR DESCRIPTION
Added some exception handling around localStorage.setItem(), and optionally pass the exception to a cacheError() callback if defined. My use case is to catch any QUOTA_EXCEEDED_ERR exceptions, and to use the callback to selectively clean up some cached items in that event. I couldn't find a better way to check for over limit errors, I'm not sure if this is the best approach or not.
