### PR TITLE
set timestamp safely on response

### DIFF
--- a/jquery-ajax-localstorage-cache.js
+++ b/jquery-ajax-localstorage-cache.js
@@ -43,6 +43,7 @@ $.ajaxPrefilter( function( options, originalOptions, jqXHR ) {
 
       // Save the data to localStorage catching exceptions (possibly QUOTA_EXCEEDED_ERR)
       try {
+        localStorage.setItem( cacheKey  + 'cachettl', +new Date() + 1000 * 60 * 60 * hourstl );
         localStorage.setItem( cacheKey, strdata );
       } catch (e) {
         // Remove any incomplete data that may have been saved before the exception was caught
@@ -54,10 +55,5 @@ $.ajaxPrefilter( function( options, originalOptions, jqXHR ) {
       if ( options.realsuccess ) options.realsuccess( data );
     };
 
-    // store timestamp
-    if ( ! ttl || ttl === 'expired' ) {
-      localStorage.setItem( cacheKey  + 'cachettl', +new Date() + 1000 * 60 * 60 * hourstl );
-    }
-    
   }
 });

--- a/jquery-ajax-localstorage-cache.js
+++ b/jquery-ajax-localstorage-cache.js
@@ -20,7 +20,6 @@ $.ajaxPrefilter( function( options, originalOptions, jqXHR ) {
   if ( ttl && ttl < +new Date() ){
     localStorage.removeItem( cacheKey );
     localStorage.removeItem( cacheKey  + 'cachettl' );
-    ttl = 'expired';
   }
   
   var value = localStorage.getItem( cacheKey );


### PR DESCRIPTION
www.gruntjs.com is running into a problem right now in chrome where when trying to set the TTL its throwing an exception due to localStorage being full. It looks like the timestamp should be set in the try catch when the response comes back.