### PR TITLE
Prevent cache keys from containing 'undefined'

### DIFF
--- a/jquery-ajax-localstorage-cache.js
+++ b/jquery-ajax-localstorage-cache.js
@@ -9,7 +9,7 @@ $.ajaxPrefilter( function( options, originalOptions, jqXHR ) {
   var hourstl = options.cacheTTL || 5;
 
   var cacheKey = options.cacheKey || 
-                 options.url.replace( /jQuery.*/,'' ) + options.type + options.data;
+                 options.url.replace( /jQuery.*/,'' ) + options.type + (options.data || '');
   
   // isCacheValid is a function to validate cache
   if ( options.isCacheValid &&  ! options.isCacheValid() ){


### PR DESCRIPTION
Line 12's options.data was more often than not `undefined`, so I prevented this by giving it an or-default '' value. It wasn't breaking anything, I just thought it was really ugly.
