### PR TITLE
$.ajaxPrefilter storage access bug fix

### DIFF
--- a/jquery-ajax-localstorage-cache.js
+++ b/jquery-ajax-localstorage-cache.js
@@ -22,14 +22,14 @@
      * @param options {Object} Options for the ajax call, modified with ajax standard settings
      */
     $.ajaxPrefilter(function(options){
-        var storage = (options.localCache === true) ? window.localStorage : options.localCache,
-            hourstl = options.cacheTTL || 5,
+        var storage = (options.localCache === true) ? window.localStorage : options.localCache;
+        if (!storage) return;
+
+        var hourstl = options.cacheTTL || 5,
             cacheKey = genCacheKey(options),
             ttl = storage.getItem(cacheKey + 'cachettl'),
             cacheValid = options.isCacheValid,
             value;
-
-        if (!storage) return;
 
         if (cacheValid && typeof cacheValid === 'function' && !cacheValid()){
             storage.removeItem(cacheKey);


### PR DESCRIPTION
Fix bug in $.ajaxPrefilter to not access storage to get the current item if it's not set because it's not available or localStorage isn't being used.