### PR TITLE
Add response validation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ It provides a client-side cache for AJAX responses intended to save bandwith and
 		cacheKey     : 'post',      // optional.
 		isCacheValid : function(){  // optional.
 			return true;
+		},
+		isResponseValid : function(data, status, jqXHR){  // optional.
+			return data.code === '0';
 		}
 	}).done(function(response){
 	    // The response is available here.

--- a/jquery-ajax-localstorage-cache.js
+++ b/jquery-ajax-localstorage-cache.js
@@ -71,6 +71,7 @@
             hourstl = options.cacheTTL || 5,
             cacheKey = options.cacheKey = genCacheKey(options),
             cacheValid = options.isCacheValid,
+            responseValid = options.isResponseValid,
             ttl,
             value;
 
@@ -97,18 +98,22 @@
                 var strdata = data,
                     dataType = this.dataType || jqXHR.getResponseHeader('Content-Type');
 
-                if (dataType.toLowerCase().indexOf('json') !== -1) strdata = JSON.stringify(data);
+                if ( ! (responseValid && typeof responseValid === 'function' && ! responseValid(data, status, jqXHR)) ) {
 
-                // Save the data to storage catching exceptions (possibly QUOTA_EXCEEDED_ERR)
-                try {
-                    storage.setItem(cacheKey, strdata);
-                    // Store timestamp and dataType
-                    storage.setItem(cacheKey + 'cachettl', +new Date() + 1000 * 60 * 60 * hourstl);
-                    storage.setItem(cacheKey + 'dataType', dataType);
-                } catch (e) {
-                    // Remove any incomplete data that may have been saved before the exception was caught
-                    removeFromStorage(storage, cacheKey);
-                    console.log('Cache Error:'+e, cacheKey, strdata);
+                    if (dataType.toLowerCase().indexOf('json') !== -1) strdata = JSON.stringify(data);
+
+                    // Save the data to storage catching exceptions (possibly QUOTA_EXCEEDED_ERR)
+                    try {
+                        storage.setItem(cacheKey, strdata);
+                        // Store timestamp and dataType
+                        storage.setItem(cacheKey + 'cachettl', +new Date() + 1000 * 60 * 60 * hourstl);
+                        storage.setItem(cacheKey + 'dataType', dataType);
+                    } catch (e) {
+                        // Remove any incomplete data that may have been saved before the exception was caught
+                        removeFromStorage(storage, cacheKey);
+                        console.log('Cache Error:'+e, cacheKey, strdata);
+                    }
+
                 }
 
                 if (options.realsuccess) options.realsuccess(data, status, jqXHR);


### PR DESCRIPTION
Most of similar plugins I saw had feature to validate response before storing in cache, for example:
http://guzzle3.readthedocs.io/plugins/cache-plugin.html#custom-caching-decision
https://github.com/Kevinrob/guzzle-cache-middleware/tree/master/src/Strategy
For example, we do not want to store error responses.